### PR TITLE
Use load event for the linnk[import] elements instead

### DIFF
--- a/spec/customElements.js
+++ b/spec/customElements.js
@@ -316,12 +316,12 @@ function appendToc() {
     document.body.insertBefore(container, document.body.children[0]);
 }
 
-document.addEventListener('HTMLImportsLoaded', function() {
-    inlineImports(document);
+document.addEventListener('load', function(e) {
+    var el = e.target;
+    if (el.rel === 'import') {
+        inlineImports(el.import);
+        el.parentNode.replaceChild(adoptBody(el.import.body), el);
+    }
+}, true);
 
-    // Wait for all the inlined elements to be upgraded
-    // setTimeout of 0ms doesn't work with IE for reasons unknown
-    // but 100ms seems to work reliably on my machine. This should
-    // be made more reliable...
-    setTimeout(appendToc, 100);
-});
+document.addEventListener('HTMLImportsLoaded', appendToc);


### PR DESCRIPTION
This allows the main doc to be updated as the imports load.
